### PR TITLE
Add initial docs and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # VibeServing
-Defining the end-to-end AI web
+
+VibeServing explores services implemented directly by neural models. Instead of writing server code in the traditional sense, we prompt a model—the **VibeServer**—to handle HTTP requests and produce responses. A **VibeClient** can be any interface that communicates with the VibeServer, including a browser, scripts, or the planned dashboard.
+
+The approach draws inspiration from "vibe coding" (leaning on large language models to generate code and handle changes) and "Software 2.0" (where the core logic is a trained model). Our goal is to build tooling and documentation that make it easy to experiment with model-driven services.
+
+See the [docs](docs/) directory for the project overview, roadmap, policies, and research notes.

--- a/docs/dashboard_spec.md
+++ b/docs/dashboard_spec.md
@@ -1,0 +1,16 @@
+# Dashboard / Mission Control Specification
+
+The dashboard provides a unified interface for interacting with a VibeServer during development.
+
+## Key features
+
+1. **Prompt panel** – displays the current server prompt and allows edits.
+2. **Traffic panel** – shows incoming requests and outgoing responses in real time.
+3. **Browser panel** – embedded view to interact with the VibeServer as a user would.
+4. **Tester panel** – run automated tests against the VibeServer and display results.
+
+## Implementation notes
+
+* The dashboard should run locally with minimal setup—ideally a simple Python or JavaScript server.
+* Panels can be arranged using a lightweight web framework (for example, a single-page app served by Flask or Node/Express).
+* Initial versions may rely on mock data; integration with the actual VibeServer and VibeTester will come later.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,15 @@
+# Getting Started
+
+These instructions describe a minimal local setup. They do not require installing heavy dependencies, but assume you have Python 3 installed.
+
+1. Clone this repository.
+2. Install dependencies (placeholder):
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the toy VibeServer:
+   ```bash
+   python examples/simple_server.py
+   ```
+
+The example server simply echoes requests using an LLM call (not yet implemented). Future updates will include a full example and a test harness.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,7 @@
+# Overview
+
+VibeServing is an approach to building services where a neural model acts as the server itself. The inputs are HTTP requests and the outputs are the responses, with optional side channels for monitoring and control. The idea draws on "vibe coding"—leaning heavily on large language models to generate and adapt code—and "Software 2.0," where the core of the application is a trained model rather than handcrafted logic.
+
+A **VibeServer** is a neural network model (for example, a large language model or a distilled variant) that directly handles web requests. A **VibeClient** is any interface that communicates with the VibeServer, whether programmatically or through a testing dashboard. Together, these form the foundation of an end-to-end AI web.
+
+This repository captures experiments, documentation, and tooling for exploring VibeServing.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,9 @@
+# Project Policies
+
+These guidelines keep work focused and traceable while maintaining a fast R&D pace.
+
+* Keep commits small and descriptive. Summaries should explain **why** the change was made.
+* Update documentation whenever prompts, tests, or workflows change.
+* Prefer simple solutions over heavy frameworks. Early prototypes can rely on scripts and small modules.
+* Record research findings in `docs/research_notes.md` so future contributors have context.
+* Agents should document any local setup steps or environment quirks in `docs/getting_started.md`.

--- a/docs/research_notes.md
+++ b/docs/research_notes.md
@@ -1,0 +1,7 @@
+# Research Notes
+
+Use this file to capture relevant papers, blog posts, or experiments related to VibeServing. Summaries and links help others catch up quickly.
+
+*Initial notes*
+- Joel Spolsky's "Painless Functional Specifications" for guidance on lightweight specs.
+- Discussions around "vibe coding" and "Software 2.0" as inspiration for end-to-end model-driven services.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+This project is exploratory. The milestones below give a rough sense of priority but are expected to evolve.
+
+1. **Minimal VibeServer prototype**
+   - HTTP wrapper that forwards requests to an LLM.
+   - Simple prompt to define a toy service.
+2. **Test harness**
+   - Scripts to send requests and verify responses.
+   - Baseline tests for regression.
+3. **Dashboard / mission control**
+   - Web interface to interact with the VibeServer.
+   - Panels for request logs, an embedded browser to see responses, and controls for running tests.
+4. **Deployment tooling**
+   - Scripts or container setup to host a VibeServer publicly.
+5. **Research website and paper**
+   - Public site showcasing the ideas.
+   - Collect findings for a potential paper.

--- a/examples/simple_server.py
+++ b/examples/simple_server.py
@@ -1,0 +1,20 @@
+"""Placeholder example for a minimal VibeServer.
+
+This script is intentionally lightweight. It outlines how an HTTP request might be
+forwarded to a language model and the response returned.
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        # TODO: integrate LLM call here
+        self.wfile.write(b"Hello from the VibeServer placeholder\n")
+
+if __name__ == "__main__":
+    server = HTTPServer(("localhost", 8000), Handler)
+    print("Serving on http://localhost:8000")
+    server.serve_forever()


### PR DESCRIPTION
## Summary
- define VibeServing, VibeServer, and VibeClient in README
- add project overview, roadmap, policies, and research notes
- include getting started guide and dashboard specification
- add placeholder example `simple_server.py`

## Testing
- `python -m py_compile examples/simple_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68430900a9bc8325a4e509d6a69f7be3