### PR TITLE
Rename dashboard to VibeStudio, add example service doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # VibeServing
 
-VibeServing explores services implemented directly by neural models. Instead of writing server code in the traditional sense, we prompt a model—the **VibeServer**—to handle HTTP requests and produce responses. A **VibeClient** can be any interface that communicates with the VibeServer, including a browser, scripts, or the planned dashboard.
+VibeServing explores services implemented directly by neural models. Instead of writing server code in the traditional sense, we prompt a model—the **VibeServer**—to handle HTTP requests and produce responses. A **VibeClient** can be any interface that communicates with the VibeServer, including a browser, scripts, or the planned **VibeStudio** dashboard.
 
 The approach draws inspiration from "vibe coding" (leaning on large language models to generate code and handle changes) and "Software 2.0" (where the core logic is a trained model). Our goal is to build tooling and documentation that make it easy to experiment with model-driven services.
 
 See the [docs](docs/) directory for the project overview, roadmap, policies, and research notes.
+The [example service](docs/example_service.md) describes the first minimal VibeServer implementation.

--- a/docs/example_service.md
+++ b/docs/example_service.md
@@ -1,0 +1,21 @@
+# First Example Service
+
+The initial service demonstrates how a VibeServer can forward requests to a language model. It runs locally using the `examples/simple_server.py` script.
+
+## Behavior
+
+1. Accepts HTTP GET requests at `/`.
+2. For each request the server sends a short prompt to an LLM that echoes the path and query parameters.
+3. The response from the LLM is returned as plain text.
+
+This simple interaction exercises the wiring between the HTTP wrapper and the LLM API.
+
+## Development needs
+
+* Implement the LLM call within `examples/simple_server.py`. The call can use OpenAI's API (an API key is required) and should return the model's text output.
+* Add error handling for network failures or invalid responses.
+
+## Testing tooling
+
+* Use Python's `unittest` module to send sample requests and verify the text returned by the server contains the echoed path.
+* Include a small test script under `examples/` once the LLM integration is in place.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -12,4 +12,6 @@ These instructions describe a minimal local setup. They do not require installin
    python examples/simple_server.py
    ```
 
-The example server simply echoes requests using an LLM call (not yet implemented). Future updates will include a full example and a test harness.
+The example server simply echoes requests using an LLM call (not yet implemented). See [example_service.md](example_service.md) for details on the planned behavior and test tooling.
+
+VibeStudio will provide a graphical view of prompts and traffic once the server is integrated.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,6 +2,6 @@
 
 VibeServing is an approach to building services where a neural model acts as the server itself. The inputs are HTTP requests and the outputs are the responses, with optional side channels for monitoring and control. The idea draws on "vibe coding"—leaning heavily on large language models to generate and adapt code—and "Software 2.0," where the core of the application is a trained model rather than handcrafted logic.
 
-A **VibeServer** is a neural network model (for example, a large language model or a distilled variant) that directly handles web requests. A **VibeClient** is any interface that communicates with the VibeServer, whether programmatically or through a testing dashboard. Together, these form the foundation of an end-to-end AI web.
+A **VibeServer** is a neural network model (for example, a large language model or a distilled variant) that directly handles web requests. A **VibeClient** is any interface that communicates with the VibeServer, whether programmatically or through the **VibeStudio** dashboard. Together, these form the foundation of an end-to-end AI web.
 
 This repository captures experiments, documentation, and tooling for exploring VibeServing.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,11 +4,11 @@ This project is exploratory. The milestones below give a rough sense of priority
 
 1. **Minimal VibeServer prototype**
    - HTTP wrapper that forwards requests to an LLM.
-   - Simple prompt to define a toy service.
+   - Simple prompt to define a toy service (see [example_service.md](example_service.md)).
 2. **Test harness**
    - Scripts to send requests and verify responses.
    - Baseline tests for regression.
-3. **Dashboard / mission control**
+3. **VibeStudio / mission control**
    - Web interface to interact with the VibeServer.
    - Panels for request logs, an embedded browser to see responses, and controls for running tests.
 4. **Deployment tooling**

--- a/docs/vibestudio_spec.md
+++ b/docs/vibestudio_spec.md
@@ -1,6 +1,6 @@
-# Dashboard / Mission Control Specification
+# VibeStudio / Mission Control Specification
 
-The dashboard provides a unified interface for interacting with a VibeServer during development.
+VibeStudio provides a unified interface for interacting with a VibeServer during development.
 
 ## Key features
 
@@ -11,6 +11,6 @@ The dashboard provides a unified interface for interacting with a VibeServer dur
 
 ## Implementation notes
 
-* The dashboard should run locally with minimal setup—ideally a simple Python or JavaScript server.
+* VibeStudio should run locally with minimal setup—ideally a simple Python or JavaScript server.
 * Panels can be arranged using a lightweight web framework (for example, a single-page app served by Flask or Node/Express).
 * Initial versions may rely on mock data; integration with the actual VibeServer and VibeTester will come later.


### PR DESCRIPTION
## Summary
- rename dashboard references to **VibeStudio**
- add an initial `example_service.md` describing the first VibeServer
- link the new doc from README and getting started guide

## Testing
- `python examples/simple_server.py` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6843120aeedc8325a280be11c354c1fd