### PR TITLE
Add initial VibeStudio dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ The approach draws inspiration from "vibe coding" (leaning on large language mod
 See the [docs](docs/) directory for the project overview, roadmap, policies, and research notes.
 See [docs/getting_started.md](docs/getting_started.md) for setup instructions to run the example service.
 The [example service](docs/example_service.md) describes the first minimal VibeServer implementation.
-The new [VibeStudio design overview](docs/vibestudio_design.md) explains the dashboard architecture and lists the steps toward a working release.
+The new [VibeStudio design overview](docs/vibestudio_design.md) explains the dashboard architecture and lists the steps toward a working release. An initial implementation lives under `vibestudio/` and can be started with `python -m vibestudio.studio`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,4 +24,12 @@ python -m unittest examples.test_simple_server
 ```
 See [example_service.md](example_service.md) for more details on the design and tests.
 
-VibeStudio will provide a graphical view of prompts and traffic once the server is integrated.
+5. Launch VibeStudio in a second terminal:
+   ```bash
+   python -m vibestudio.studio
+   ```
+   Then open http://localhost:8500 in your browser. The dashboard lists the
+   examples and shows how to run their tests.
+
+VibeStudio currently surfaces example information only; later versions will also
+display live traffic and prompts from a running VibeServer.

--- a/docs/vibestudio_design.md
+++ b/docs/vibestudio_design.md
@@ -23,10 +23,11 @@ and providing a step‑by‑step roadmap to a working implementation.
 ## Roadmap
 
 1. **Static prototype**
-   - Create a basic Flask (or Node) server that serves a static page with
-     placeholder panels.
+   - Create a small Python server that serves a static page with placeholder
+     panels. The implementation lives in `vibestudio/studio.py`.
    - Mock data for requests, responses, and tests so the layout can be
-     exercised.
+     exercised. The server also exposes `/api/examples` which lists runnable
+     examples from the repository.
 2. **Live traffic and prompt editing**
    - Connect to the toy VibeServer from `examples/` and display incoming
      requests and outgoing responses in real time.

--- a/vibestudio/__init__.py
+++ b/vibestudio/__init__.py
@@ -1,0 +1,1 @@
+"""Initial VibeStudio package."""

--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>VibeStudio</title>
+<style>
+body { font-family: sans-serif; margin: 20px; }
+pre { background: #f0f0f0; padding: 8px; }
+.example { margin-bottom: 20px; }
+</style>
+</head>
+<body>
+<h1>VibeStudio</h1>
+<p>This page lists available examples and how to run their tests.</p>
+<div id="examples">Loading...</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -1,0 +1,30 @@
+async function loadExamples() {
+  const resp = await fetch('/api/examples');
+  const examples = await resp.json();
+  const container = document.getElementById('examples');
+  container.innerHTML = '';
+  examples.forEach((ex) => {
+    const div = document.createElement('div');
+    div.className = 'example';
+    const title = document.createElement('h2');
+    title.textContent = ex.name;
+    div.appendChild(title);
+    const runLabel = document.createElement('div');
+    runLabel.textContent = 'Run the example:';
+    div.appendChild(runLabel);
+    const run = document.createElement('pre');
+    run.textContent = ex.run;
+    div.appendChild(run);
+    if (ex.test) {
+      const testLabel = document.createElement('div');
+      testLabel.textContent = 'Run the tests:';
+      div.appendChild(testLabel);
+      const test = document.createElement('pre');
+      test.textContent = ex.test;
+      div.appendChild(test);
+    }
+    container.appendChild(div);
+  });
+}
+
+window.addEventListener('load', loadExamples);

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -1,0 +1,51 @@
+import json
+import os
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse
+
+HERE = os.path.dirname(__file__)
+REPO_ROOT = os.path.dirname(HERE)
+
+
+def gather_examples():
+    """Return a list of example run/test commands from the repo."""
+    examples_dir = os.path.join(REPO_ROOT, "examples")
+    items = []
+    for filename in os.listdir(examples_dir):
+        if filename.endswith(".py") and not filename.startswith("test_"):
+            name = os.path.splitext(filename)[0]
+            run_cmd = f"python examples/{filename}"
+            test_file = os.path.join(examples_dir, f"test_{filename}")
+            test_cmd = None
+            if os.path.exists(test_file):
+                test_mod = os.path.splitext(os.path.basename(test_file))[0]
+                test_cmd = f"python -m unittest examples.{test_mod}"
+            items.append({"name": name, "run": run_cmd, "test": test_cmd})
+    return items
+
+
+class StudioHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=os.path.join(HERE, "static"), **kwargs)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/examples":
+            data = json.dumps(gather_examples()).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            super().do_GET()
+
+
+def run(host="localhost", port=8500):
+    server = HTTPServer((host, port), StudioHandler)
+    print(f"VibeStudio running on http://{host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- create `vibestudio` package with a simple HTTP server
- serve a static dashboard that lists available examples and test commands
- load examples from `examples/` at startup via `/api/examples`
- document how to run VibeStudio in `README.md` and `getting_started.md`
- update VibeStudio design document

## Testing
- `python -m unittest examples.test_simple_server`

------
https://chatgpt.com/codex/tasks/task_e_68434ef787c88325a4d0cb18205c09a9