### PR TITLE
Implement end-to-end VibeStudio prototype

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,8 +28,6 @@ See [example_service.md](example_service.md) for more details on the design and 
    ```bash
    python -m vibestudio.studio
    ```
-   Then open http://localhost:8500 in your browser. The dashboard lists the
-   examples and shows how to run their tests.
-
-VibeStudio currently surfaces example information only; later versions will also
-display live traffic and prompts from a running VibeServer.
+   Then open http://localhost:8500 in your browser. The dashboard now starts a
+   toy VibeServer, shows its prompt, logs traffic, and lets you run the
+   automated tests from the Tester panel.

--- a/docs/vibestudio_design.md
+++ b/docs/vibestudio_design.md
@@ -43,3 +43,10 @@ and providing a step‑by‑step roadmap to a working implementation.
 
 This staged approach keeps the initial implementation small while making
 it easy to expand VibeStudio alongside the rest of the project.
+
+## Current status
+
+The implementation in this repository now covers stages 1–3. Running
+`python -m vibestudio.studio` starts the dashboard along with a toy
+VibeServer so you can edit the prompt, watch live traffic, and execute
+the unit tests from the Tester panel.

--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -5,13 +5,36 @@
 <title>VibeStudio</title>
 <style>
 body { font-family: sans-serif; margin: 20px; }
-pre { background: #f0f0f0; padding: 8px; }
-.example { margin-bottom: 20px; }
+pre { background: #f0f0f0; padding: 8px; white-space: pre-wrap; }
+.panel { border: 1px solid #ccc; padding: 10px; margin-bottom: 20px; }
+iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
 </style>
 </head>
 <body>
 <h1>VibeStudio</h1>
-<p>This page lists available examples and how to run their tests.</p>
+<div class="panel" id="prompt-panel">
+  <h2>Prompt</h2>
+  <textarea id="prompt" rows="4" cols="80"></textarea><br />
+  <button id="save-prompt">Save</button>
+</div>
+
+<div class="panel" id="traffic-panel">
+  <h2>Traffic</h2>
+  <pre id="traffic">Loading...</pre>
+</div>
+
+<div class="panel" id="browser-panel">
+  <h2>Browser</h2>
+  <iframe id="browser" src="http://localhost:8000/"></iframe>
+</div>
+
+<div class="panel" id="tester-panel">
+  <h2>Tester</h2>
+  <button id="run-tests">Run Tests</button>
+  <pre id="test-output"></pre>
+</div>
+
+<h2>Examples</h2>
 <div id="examples">Loading...</div>
 <script src="script.js"></script>
 </body>

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -27,4 +27,40 @@ async function loadExamples() {
   });
 }
 
-window.addEventListener('load', loadExamples);
+async function loadPrompt() {
+  const resp = await fetch('/api/prompt');
+  const data = await resp.json();
+  document.getElementById('prompt').value = data.prompt;
+}
+
+async function savePrompt() {
+  const prompt = document.getElementById('prompt').value;
+  await fetch('/api/prompt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+}
+
+async function loadLogs() {
+  const resp = await fetch('/api/logs');
+  const logs = await resp.json();
+  const pre = document.getElementById('traffic');
+  pre.textContent = logs.map(l => `${l.request} -> ${l.response}`).join('\n');
+}
+
+async function runTests() {
+  document.getElementById('test-output').textContent = 'Running...';
+  const resp = await fetch('/api/run_tests', { method: 'POST' });
+  const data = await resp.json();
+  document.getElementById('test-output').textContent = data.output;
+}
+
+window.addEventListener('load', () => {
+  loadExamples();
+  loadPrompt();
+  loadLogs();
+  document.getElementById('save-prompt').addEventListener('click', savePrompt);
+  document.getElementById('run-tests').addEventListener('click', runTests);
+  setInterval(loadLogs, 2000);
+});

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -1,10 +1,15 @@
 import json
 import os
-from http.server import SimpleHTTPRequestHandler, HTTPServer
+import threading
+import subprocess
+from http.server import BaseHTTPRequestHandler, SimpleHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse
 
 HERE = os.path.dirname(__file__)
 REPO_ROOT = os.path.dirname(HERE)
+
+PROMPT = "Echo the following HTTP path and query exactly:\n{path}"
+LOGS = []
 
 
 def gather_examples():
@@ -24,27 +29,84 @@ def gather_examples():
     return items
 
 
+class ExampleHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        global PROMPT
+        text = PROMPT.format(path=self.path)
+        LOGS.append({"request": self.path, "response": text})
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write(text.encode("utf-8"))
+
+
+class _ExampleServerThread(threading.Thread):
+    def __init__(self, host="localhost", port=8000):
+        super().__init__(daemon=True)
+        self.server = HTTPServer((host, port), ExampleHandler)
+
+    def run(self):
+        self.server.serve_forever()
+
+    def stop(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+
 class StudioHandler(SimpleHTTPRequestHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=os.path.join(HERE, "static"), **kwargs)
 
+    def _send_json(self, data):
+        payload = json.dumps(data).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
     def do_GET(self):
         parsed = urlparse(self.path)
         if parsed.path == "/api/examples":
-            data = json.dumps(gather_examples()).encode("utf-8")
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(data)))
-            self.end_headers()
-            self.wfile.write(data)
+            self._send_json(gather_examples())
+        elif parsed.path == "/api/prompt":
+            self._send_json({"prompt": PROMPT})
+        elif parsed.path == "/api/logs":
+            self._send_json(LOGS)
         else:
             super().do_GET()
 
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/prompt":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            data = json.loads(body or b"{}")
+            global PROMPT
+            PROMPT = data.get("prompt", PROMPT)
+            self._send_json({"status": "ok"})
+        elif parsed.path == "/api/run_tests":
+            result = subprocess.run([
+                "python",
+                "-m",
+                "unittest",
+                "examples.test_simple_server",
+            ], capture_output=True, text=True)
+            self._send_json({"output": result.stdout + result.stderr, "returncode": result.returncode})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
 
 def run(host="localhost", port=8500):
+    example = _ExampleServerThread()
+    example.start()
     server = HTTPServer((host, port), StudioHandler)
     print(f"VibeStudio running on http://{host}:{port}")
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    finally:
+        example.stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Prompt, Traffic, Browser and Tester panels to VibeStudio
- spin up a toy example server alongside the studio
- expose APIs for prompt editing, logs and test execution
- document the updated studio usage and status

## Testing
- `python -m unittest examples.test_simple_server`

------
https://chatgpt.com/codex/tasks/task_e_684352e432a083258efdbd0224909561