### PR TITLE
Add restart server functionality in VibeStudio

### DIFF
--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -16,6 +16,7 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
   <h2>Prompt</h2>
   <textarea id="prompt" rows="4" cols="80"></textarea><br />
   <button id="save-prompt">Save</button>
+  <button id="restart-server">Restart Server</button>
 </div>
 
 <div class="panel" id="traffic-panel">

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -42,6 +42,19 @@ async function savePrompt() {
   });
 }
 
+async function restartServer() {
+  const prompt = document.getElementById('prompt').value;
+  await fetch('/api/restart', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+  document.getElementById('traffic').textContent = '';
+  const iframe = document.getElementById('browser');
+  iframe.src = 'http://localhost:8000/';
+  loadLogs();
+}
+
 async function loadLogs() {
   const resp = await fetch('/api/logs');
   const logs = await resp.json();
@@ -61,6 +74,7 @@ window.addEventListener('load', () => {
   loadPrompt();
   loadLogs();
   document.getElementById('save-prompt').addEventListener('click', savePrompt);
+  document.getElementById('restart-server').addEventListener('click', restartServer);
   document.getElementById('run-tests').addEventListener('click', runTests);
   setInterval(loadLogs, 2000);
 });

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -10,6 +10,17 @@ REPO_ROOT = os.path.dirname(HERE)
 
 PROMPT = "Echo the following HTTP path and query exactly:\n{path}"
 LOGS = []
+_SERVER_THREAD = None
+
+
+def _start_example_server():
+    """(Re)start the background example server."""
+    global _SERVER_THREAD
+    if _SERVER_THREAD is not None:
+        _SERVER_THREAD.stop()
+        _SERVER_THREAD.join()
+    _SERVER_THREAD = _ExampleServerThread()
+    _SERVER_THREAD.start()
 
 
 def gather_examples():
@@ -85,6 +96,15 @@ class StudioHandler(SimpleHTTPRequestHandler):
             global PROMPT
             PROMPT = data.get("prompt", PROMPT)
             self._send_json({"status": "ok"})
+        elif parsed.path == "/api/restart":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            data = json.loads(body or b"{}")
+            global PROMPT, LOGS
+            PROMPT = data.get("prompt", PROMPT)
+            LOGS = []
+            _start_example_server()
+            self._send_json({"status": "restarted"})
         elif parsed.path == "/api/run_tests":
             result = subprocess.run([
                 "python",
@@ -99,15 +119,16 @@ class StudioHandler(SimpleHTTPRequestHandler):
 
 
 def run(host="localhost", port=8500):
-    example = _ExampleServerThread()
-    example.start()
+    _start_example_server()
     server = HTTPServer((host, port), StudioHandler)
     print(f"VibeStudio running on http://{host}:{port}")
     try:
         server.serve_forever()
     finally:
-        example.stop()
+        if _SERVER_THREAD is not None:
+            _SERVER_THREAD.stop()
 
 
 if __name__ == "__main__":
     run()
+


### PR DESCRIPTION
## Summary
- support restarting the example VibeServer from the dashboard
- clear logs and reload browser when restarting
- add "Restart Server" button to the UI

## Testing
- `python -m unittest examples.test_simple_server`

------
https://chatgpt.com/codex/tasks/task_e_68435a2863d0832588cb2faf6c04a59a