### PR TITLE
Add example prompt chooser

### DIFF
--- a/docs/vibestudio_design.md
+++ b/docs/vibestudio_design.md
@@ -69,5 +69,6 @@ The implementation in this repository now covers stages 1–3. Running
 `python -m vibestudio.studio` starts the dashboard along with a small
 server that proxies HTTP requests to the LLM using the active prompts.
 You can edit prompts, watch traffic, and execute the unit tests from the
-Tester panel. The `examples/simple_server.py` script remains as a minimal
-standalone demonstration of the same behaviour.
+Tester panel. A dropdown next to the Service Prompt lets you quickly load
+example prompts from the repository. The `examples/simple_server.py`
+script remains as a minimal standalone demonstration of the same behaviour.

--- a/docs/vibestudio_interactions.md
+++ b/docs/vibestudio_interactions.md
@@ -1,0 +1,5 @@
+# VibeStudio Interactions
+
+This document describes how to use the dashboard controls. The Service Prompt panel features a dropdown labelled `prompt-chooser` populated from `/api/examples`. Selecting an example fills the Service Prompt textarea with that example's prompt, making it easy to try different setups.
+
+Other panels continue to function as outlined in `vibestudio_design.md`: you can edit prompts, restart the server, view traffic, and run tests from the Tester panel.

--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -14,7 +14,8 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
 <h1>VibeStudio</h1>
 <div class="panel" id="prompt-panel">
   <h2>Service Prompt</h2>
-  <textarea id="prompt" rows="4" cols="80"></textarea><br />
+  <textarea id="prompt" rows="4" cols="80"></textarea>
+  <select id="prompt-chooser"></select><br />
   <button id="save-prompt">Save</button>
 </div>
 

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -2,7 +2,9 @@ async function loadExamples() {
   const resp = await fetch('/api/examples');
   const examples = await resp.json();
   const container = document.getElementById('examples');
+  const chooser = document.getElementById('prompt-chooser');
   container.innerHTML = '';
+  chooser.innerHTML = '<option value="">Select example...</option>';
   examples.forEach((ex) => {
     const div = document.createElement('div');
     div.className = 'example';
@@ -16,6 +18,11 @@ async function loadExamples() {
         document.getElementById('prompt').value = ex.prompt;
       });
       div.appendChild(btn);
+
+      const opt = document.createElement('option');
+      opt.value = ex.prompt;
+      opt.textContent = ex.name;
+      chooser.appendChild(opt);
     }
     const runLabel = document.createElement('div');
     runLabel.textContent = 'Run the example:';
@@ -102,5 +109,10 @@ window.addEventListener('load', () => {
   document.getElementById('save-meta').addEventListener('click', saveMetaPrompt);
   document.getElementById('restart-server').addEventListener('click', restartServer);
   document.getElementById('run-tests').addEventListener('click', runTests);
+  document.getElementById('prompt-chooser').addEventListener('change', (e) => {
+    if (e.target.value) {
+      document.getElementById('prompt').value = e.target.value;
+    }
+  });
   setInterval(loadLogs, 2000);
 });


### PR DESCRIPTION
## Summary
- add dropdown to select example prompts
- populate dropdown from `/api/examples`
- update docs with new control description
- create docs/vibestudio_interactions.md

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844743384cc8325a15a3c723ad0e598