### PR TITLE
Improve VibeStudio debugging support

### DIFF
--- a/docs/vibestudio_design.md
+++ b/docs/vibestudio_design.md
@@ -30,8 +30,10 @@ messages are surrounded by triple braces on their own lines, for example
 `{{{ system prompt }}}`, to clearly separate them from ordinary HTTP content.
 VibeStudio then sends an HTTP `GET /` request over that conversation and
 shows the raw request in the Traffic panel. The model replies with an
-HTTP response, which is logged and rendered in the Browser panel. To
-mirror the real VibeServer behaviour, the bundled example server includes
+HTTP response, which is logged and rendered in the Browser panel. Meta
+messages returned by the model are captured separately so they can be
+displayed in a **Meta Chat** panel for debugging. To mirror the real
+VibeServer behaviour, the bundled example server includes
 the meta prompt at the top of each response, wrapped in triple braces
 (`{{{ meta }}}`). All subsequent user actions are proxied as HTTP
 requests and responses. Future versions may also forward out‑of‑band

--- a/docs/vibestudio_interactions.md
+++ b/docs/vibestudio_interactions.md
@@ -130,7 +130,7 @@ Content-Type: text/html
 
 ## Logging and out‑of‑band messages
 
-The backend keeps an in‑memory list `LOGS` containing dictionaries with `request` and `response` fields. The Traffic panel polls `/api/logs` every few seconds to display these entries. Any additional metadata returned by the LLM could be surfaced in a similar way—for example, diagnostics wrapped in triple braces.
+The backend keeps an in‑memory list `LOGS` containing dictionaries with `request`, `status`, and `response` fields. The Traffic panel polls `/api/logs` every few seconds to display these entries. Meta messages wrapped in triple braces are parsed into a separate `META_LOGS` list so they can be shown in the new Meta Chat panel, indicating the direction of each message.
 
 Future versions may allow the LLM to send notifications separate from the HTTP response stream. These would travel through the backend before reaching the UI.
 

--- a/docs/vibestudio_spec.md
+++ b/docs/vibestudio_spec.md
@@ -6,9 +6,11 @@ VibeStudio provides a unified interface for interacting with a VibeServer during
 
 1. **Service Prompt panel** – displays the request-handling prompt and allows edits.
 2. **Meta Prompt panel** – shows persistent instructions stored in `vibestudio/meta_prompt.txt`.
-3. **Traffic panel** – shows incoming requests and outgoing responses in real time.
-4. **Browser panel** – embedded view to interact with the VibeServer as a user would.
-5. **Tester panel** – run automated tests against the VibeServer and display results.
+3. **Meta Chat panel** – displays meta messages exchanged with the model, showing
+   directions for debugging.
+4. **Traffic panel** – shows incoming requests and outgoing responses in real time.
+5. **Browser panel** – embedded view to interact with the VibeServer as a user would.
+6. **Tester panel** – run automated tests against the VibeServer and display results.
 
 ## Implementation notes
 

--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -26,6 +26,11 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
   <button id="restart-server">Restart Server</button>
 </div>
 
+<div class="panel" id="meta-chat-panel">
+  <h2>Meta Chat</h2>
+  <pre id="meta-chat">Loading...</pre>
+</div>
+
 <div class="panel" id="traffic-panel">
   <h2>Traffic</h2>
   <pre id="traffic">Loading...</pre>

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -90,7 +90,14 @@ async function loadLogs() {
   const resp = await fetch('/api/logs');
   const logs = await resp.json();
   const pre = document.getElementById('traffic');
-  pre.textContent = logs.map(l => `${l.request} -> ${l.response}`).join('\n');
+  pre.textContent = logs.map(l => `${l.status} ${l.request} -> ${l.response}`).join('\n');
+}
+
+async function loadMetaChat() {
+  const resp = await fetch('/api/meta_logs');
+  const logs = await resp.json();
+  const pre = document.getElementById('meta-chat');
+  pre.textContent = logs.map(l => (l.direction === 'out' ? '>> ' : '<< ') + l.text).join('\n');
 }
 
 async function runTests() {
@@ -105,6 +112,7 @@ window.addEventListener('load', () => {
   loadPrompt();
   loadMetaPrompt();
   loadLogs();
+  loadMetaChat();
   document.getElementById('save-prompt').addEventListener('click', savePrompt);
   document.getElementById('save-meta').addEventListener('click', saveMetaPrompt);
   document.getElementById('restart-server').addEventListener('click', restartServer);
@@ -115,4 +123,5 @@ window.addEventListener('load', () => {
     }
   });
   setInterval(loadLogs, 2000);
+  setInterval(loadMetaChat, 2000);
 });


### PR DESCRIPTION
## Summary
- record meta chat messages in `META_LOGS`
- expose `META_LOGS` via `/api/meta_logs` and clear on restart
- log HTTP status and errors when serving requests
- add Meta Chat panel to the UI and show statuses in Traffic panel
- document the new panel in the design and spec
- enhance unit tests to cover error logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447b93add88325996b5e5239e75928