### PR TITLE
Improve VibeStudio meta chat and logging

### DIFF
--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -29,6 +29,8 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
 <div class="panel" id="meta-chat-panel">
   <h2>Meta Chat</h2>
   <pre id="meta-chat">Loading...</pre>
+  <input id="meta-input" type="text" style="width:80%" />
+  <button id="send-meta">Send</button>
 </div>
 
 <div class="panel" id="traffic-panel">
@@ -47,8 +49,6 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
   <pre id="test-output"></pre>
 </div>
 
-<h2>Examples</h2>
-<div id="examples">Loading...</div>
 <script src="script.js"></script>
 </body>
 </html>

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -224,6 +224,15 @@ class StudioHandler(SimpleHTTPRequestHandler):
             META_LOGS = []
             _start_example_server()
             self._send_json({"status": "restarted"})
+        elif parsed.path == "/api/meta_chat":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            data = json.loads(body or b"{}")
+            text = data.get("text", "")
+            META_LOGS.append({"direction": "out", "text": text})
+            response = ExampleHandler.call_llm(ExampleHandler, text)
+            META_LOGS.append({"direction": "in", "text": response})
+            self._send_json({"response": response})
         elif parsed.path == "/api/run_tests":
             result = subprocess.run([
                 "python",


### PR DESCRIPTION
## Summary
- show a meta chat input box and send button
- append new traffic log entries instead of replacing
- remove obsolete Examples panel
- support sending meta chat messages from the UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448d81051c8325b9d0911363a571ef