### PR TITLE
Expand Traffic log to include meta messages

### DIFF
--- a/docs/vibestudio_design.md
+++ b/docs/vibestudio_design.md
@@ -34,7 +34,8 @@ HTTP response, which is logged and rendered in the Browser panel. The
 panel now includes a small address bar and Back button so you can
 navigate to specific URLs and return to previous pages. Meta messages
 returned by the model are captured separately so they can be
-displayed in a **Meta Chat** panel for debugging. To mirror the real
+displayed in a **Meta Chat** panel for debugging and also appear in the
+Traffic panel so every exchange with the LLM is visible. To mirror the real
 VibeServer behaviour, the bundled example server includes
 the meta prompt at the top of each response, wrapped in triple braces
 (`{{{ meta }}}`). All subsequent user actions are proxied as HTTP

--- a/docs/vibestudio_interactions.md
+++ b/docs/vibestudio_interactions.md
@@ -130,7 +130,12 @@ Content-Type: text/html
 
 ## Logging and out‑of‑band messages
 
-The backend keeps an in‑memory list `LOGS` containing dictionaries with `request`, `status`, and `response` fields. The Traffic panel polls `/api/logs` every few seconds to display these entries. Meta messages wrapped in triple braces are parsed into a separate `META_LOGS` list so they can be shown in the new Meta Chat panel, indicating the direction of each message.
+The backend keeps an in‑memory list `LOGS` containing a chronological record of
+all messages. HTTP requests and responses include `request`, `status`, and
+`response` fields while meta messages use a `type` of `meta_in` or `meta_out`.
+The Traffic panel polls `/api/logs` every few seconds to display every exchange.
+Meta messages are also collected in a separate `META_LOGS` list so they appear in
+the Meta Chat panel with clear direction markers.
 
 Future versions may allow the LLM to send notifications separate from the HTTP response stream. These would travel through the backend before reaching the UI.
 

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -70,7 +70,13 @@ async function loadLogs() {
   const pre = document.getElementById('traffic');
   for (let i = logIndex; i < logs.length; i++) {
     const l = logs[i];
-    pre.textContent += `${l.status} ${l.request} -> ${l.response}\n`;
+    if (l.type === 'http') {
+      pre.textContent += `${l.status} ${l.request} -> ${l.response}\n`;
+    } else if (l.type === 'meta_out') {
+      pre.textContent += `>> ${l.text}\n`;
+    } else if (l.type === 'meta_in') {
+      pre.textContent += `<< ${l.text}\n`;
+    }
   }
   logIndex = logs.length;
 }


### PR DESCRIPTION
## Summary
- log outgoing meta and service prompts to `LOGS`
- capture trailing meta channel messages and record them in `LOGS`
- show meta messages in Traffic panel
- document that meta communication now appears in the Traffic panel

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844aea06f28832589720f69e571345a