### PR TITLE
Add transcript export and log improvements

### DIFF
--- a/vibestudio/static/index.html
+++ b/vibestudio/static/index.html
@@ -66,12 +66,18 @@ iframe { width: 100%; height: 300px; border: 1px solid #ccc; }
   <iframe id="browser" src="http://localhost:8000/"></iframe>
 </div>
 
-<div class="panel" id="tester-panel">
-  <h2>Tester</h2>
-  <button id="run-tests">Run Tests</button>
-  <pre id="test-output"></pre>
-</div>
+  <div class="panel" id="tester-panel">
+    <h2>Tester</h2>
+    <button id="run-tests">Run Tests</button>
+    <pre id="test-output"></pre>
+  </div>
 
-<script src="script.js"></script>
+  <div class="panel" id="debug-panel">
+    <h2>Debug</h2>
+    <button id="copy-transcript">Copy Transcript</button>
+    <span id="copy-status" style="display:none;margin-left:10px;color:#2b8a3e;">Copied!</span>
+  </div>
+
+  <script src="script.js"></script>
 </body>
 </html>

--- a/vibestudio/static/script.js
+++ b/vibestudio/static/script.js
@@ -113,6 +113,9 @@ async function loadLogs() {
       pre.textContent += `>> ${l.text}\n`;
     } else if (l.type === 'meta_in') {
       pre.textContent += `<< ${l.text}\n`;
+    } else if (l.type === 'llm_exchange') {
+      pre.textContent += `[LLM REQUEST] ${JSON.stringify(l.request)}\n`;
+      pre.textContent += `[LLM RESPONSE] ${l.response}\n`;
     }
   }
   logIndex = logs.length;
@@ -143,6 +146,16 @@ async function runTests() {
   const data = await fetchJson('/api/run_tests', { method: 'POST' });
   if (data) {
     document.getElementById('test-output').textContent = data.output;
+  }
+}
+
+async function copyTranscript() {
+  const data = await fetchJson('/api/transcript');
+  if (data) {
+    await navigator.clipboard.writeText(JSON.stringify(data, null, 2));
+    const status = document.getElementById('copy-status');
+    status.style.display = 'inline';
+    setTimeout(() => { status.style.display = 'none'; }, 2000);
   }
 }
 
@@ -178,6 +191,8 @@ window.addEventListener('load', () => {
   document.getElementById('run-tests').addEventListener('click', runTests);
   document.getElementById('send-meta').addEventListener('click', sendMeta);
   document.getElementById('save-settings').addEventListener('click', saveSettings);
+  const ct = document.getElementById('copy-transcript');
+  if (ct) ct.addEventListener('click', copyTranscript);
   document.getElementById('prompt-chooser').addEventListener('change', (e) => {
     if (e.target.value) {
       document.getElementById('prompt').value = e.target.value;

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -157,6 +157,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
 
         global CONVERSATION
         CONVERSATION.append({"role": "user", "content": request_text})
+        llm_request = list(CONVERSATION)
         status = 200
         try:
             response_text = self.call_llm(CONVERSATION)
@@ -165,6 +166,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
             status = 500
             response_text = f"LLM error: {exc}"
         CONVERSATION.append({"role": "assistant", "content": response_text})
+        LOGS.append({"type": "llm_exchange", "request": llm_request, "response": response_text})
         lines = response_text.splitlines()
         # Trim leading blank lines so slightly malformed responses still parse
         while lines and not lines[0].strip():
@@ -297,6 +299,16 @@ class StudioHandler(SimpleHTTPRequestHandler):
             self._send_json(LOGS)
         elif parsed.path == "/api/meta_logs":
             self._send_json(META_LOGS)
+        elif parsed.path == "/api/transcript":
+            self._send_json({
+                "prompt": PROMPT,
+                "meta_prompt": META_PROMPT,
+                "model": MODEL,
+                "temperature": TEMPERATURE,
+                "thinking_time": THINKING_TIME,
+                "logs": LOGS,
+                "meta_logs": META_LOGS,
+            })
         else:
             super().do_GET()
 


### PR DESCRIPTION
## Summary
- capture full LLM request/response exchanges
- expose `/api/transcript` endpoint that returns prompts, settings, and logs
- add Debug panel with `Copy Transcript` button
- show raw LLM traffic in Traffic panel

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845fc8eacb08325b4f7ea5c021bab01