### PR TITLE
Use OpenAI Responses API

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,7 +8,7 @@ These instructions describe a minimal local setup. They do not require installin
    pip install -r requirements.txt
    ```
    This installs `openai>=1.0`, so the example server uses the
-   updated `openai.chat.completions` API.
+   updated `openai.responses` API.
 3. Set your OpenAI API key so the example can contact the model:
    ```bash
    export OPENAI_API_KEY="<your-key>"  # Linux/macOS

--- a/vibestudio/tests/test_openai_model.py
+++ b/vibestudio/tests/test_openai_model.py
@@ -10,6 +10,7 @@ class OpenAIModelEnvTest(unittest.TestCase):
         fake_response = types.SimpleNamespace()
         fake_response.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content="ok"))]
         fake_openai = types.SimpleNamespace()
+        fake_openai.responses = types.SimpleNamespace(create=mock.Mock(return_value=fake_response))
         fake_openai.chat = types.SimpleNamespace()
         fake_openai.chat.completions = types.SimpleNamespace(create=mock.Mock(return_value=fake_response))
         fake_openai.ChatCompletion = types.SimpleNamespace(create=mock.Mock(return_value=fake_response))
@@ -18,9 +19,10 @@ class OpenAIModelEnvTest(unittest.TestCase):
                 studio.MODEL = "test-model"
                 messages = [{"role": "user", "content": "prompt"}]
                 studio.ProxyHandler.call_llm(studio.ProxyHandler, messages)
-                fake_openai.chat.completions.create.assert_called_with(
+                fake_openai.responses.create.assert_called_with(
                     model="test-model",
                     messages=messages,
+                    previous_response_id=None,
                 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support `openai.responses` with `previous_response_id` in the studio proxy
- preserve threading context in the simple server example
- update tests for the new API
- mention the Responses API in the getting started docs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846060958f88325903311ff50c17c73