### PR TITLE
Add model validity checks before OpenAI calls

### DIFF
--- a/examples/simple_server.py
+++ b/examples/simple_server.py
@@ -35,7 +35,9 @@ class Handler(BaseHTTPRequestHandler):
             raise RuntimeError("OPENAI_API_KEY environment variable not set")
 
         openai.api_key = api_key
-        model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+        model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo") or "gpt-3.5-turbo"
+        if not model:
+            raise RuntimeError("Model name must be specified")
         prompt = f"Echo the following HTTP path and query exactly:\n{path}"
 
         try:

--- a/vibestudio/studio.py
+++ b/vibestudio/studio.py
@@ -120,6 +120,8 @@ class ProxyHandler(BaseHTTPRequestHandler):
 
         openai.api_key = api_key
         model = MODEL or "gpt-3.5-turbo"
+        if not model:
+            raise RuntimeError("Model name must be specified")
         LOGGER.info("Calling OpenAI model %s", model)
         LOGGER.debug("Messages: %s", messages)
         try:  # pragma: no cover - network dependent


### PR DESCRIPTION
## Summary
- prevent invalid OpenAI API calls by verifying that a model name is set before invoking the API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684608eed28083258535f6014331765e